### PR TITLE
Fix: mat-slider dashboard ng 16

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,4 @@
+# 28/06/24 mramirez
+- Se encontró que varios elementos del material-angular estaban sin funcionar, esto se debe a que se siguen usando las librerias antiguas
+- Para corregir los problemas de los mat-slider de la vista /dashboard se importo el módulo MatSliderModule en el modulo de app-material
+- Los sliders en angular 16 funcionan distinto, es necesario agregar a cada uno un input dentro con las propiedades "matSliderThumb [(ngModel)]"

--- a/src/app/app-material.module.ts
+++ b/src/app/app-material.module.ts
@@ -11,7 +11,7 @@ import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/m
 import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
 import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
 import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
-import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
+// import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -20,6 +20,7 @@ import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/lega
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
+import { MatSliderModule } from '@angular/material/slider';
 
 @NgModule({
     imports: [

--- a/src/app/imi-vars/imi-vars.component.html
+++ b/src/app/imi-vars/imi-vars.component.html
@@ -26,7 +26,9 @@
                             <mat-icon>settings_suggest</mat-icon>
                             Product
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value1" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider ngDefaultControl thumbLabel tickInterval="1" min="0" max="5" step="1"  [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value1">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value1}}</span>
                     </div>
 
@@ -35,7 +37,9 @@
                             <mat-icon>view_in_ar</mat-icon>
                             Design
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value2" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value2">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value2}}</span>
                     </div>
 
@@ -44,7 +48,9 @@
                             <mat-icon>precision_manufacturing</mat-icon>
                             Fabrication
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value3" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value3">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value3}}</span>
                     </div>
                 </mat-expansion-panel>
@@ -62,7 +68,9 @@
                             <mat-icon>lens_blur</mat-icon>
                             Materials
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value4" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value4">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value4}}</span>
                     </div>
 
@@ -71,7 +79,9 @@
                             <mat-icon>bolt</mat-icon>
                             Energy
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value5" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value5">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value5}}</span>
                     </div>
 
@@ -80,7 +90,9 @@
                             <mat-icon>device_hub</mat-icon>
                             Logistics
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value6" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value6">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value6}}</span>
                     </div>
                 </mat-expansion-panel>
@@ -98,7 +110,9 @@
                             <mat-icon>sensors</mat-icon>
                             Sensing
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value7" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value7">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value7}}</span>
                     </div>
 
@@ -107,7 +121,9 @@
                             <mat-icon>memory</mat-icon>
                             Processing
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value8" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value8">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value8}}</span>
                     </div>
 
@@ -116,7 +132,9 @@
                             <mat-icon>insights</mat-icon>
                             Actuator
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value9" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value9">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value9}}</span>
                     </div>
                 </mat-expansion-panel>
@@ -134,7 +152,9 @@
                             <mat-icon>groups</mat-icon>
                             Organization
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value10" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value10">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value10}}</span>
                     </div>
 
@@ -143,7 +163,9 @@
                             <mat-icon>public</mat-icon>
                             Impact
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value11" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value11">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value11}}</span>
                     </div>
 
@@ -152,7 +174,9 @@
                             <mat-icon>auto_awesome</mat-icon>
                             Compliance
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value12" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value12">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value12}}</span>
                     </div>
                 </mat-expansion-panel>
@@ -170,7 +194,9 @@
                             <mat-icon>model_training</mat-icon>
                             Innovation
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value13" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value13">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value13}}</span>
                     </div>
 
@@ -179,7 +205,9 @@
                             <mat-icon>attribution</mat-icon>
                             <span style="margin-left: 3px;">Intellectual property</span>
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value14" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value14">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value14}}</span>
                     </div>
 
@@ -188,7 +216,9 @@
                             <mat-icon>psychology</mat-icon>
                             Training
                         </mat-label>
-                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [(ngModel)]="sliderValues.value15" [disabled]="disabledSliders"></mat-slider>
+                        <mat-slider thumbLabel tickInterval="1" min="0" max="5" step="1" [disabled]="disabledSliders">
+                            <input matSliderThumb [(ngModel)]="sliderValues.value15">
+                        </mat-slider>
                         <span class="score-slider">{{sliderValues.value15}}</span>
                     </div>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -660,3 +660,17 @@ button p.btn-subtitle {
     font-size: 11px;
     font-weight: 400;
 }
+
+/* Estilos para todos los sliders */
+.mat-mdc-slider.mat-primary {
+    --mdc-slider-handle-color: #00C853;
+    --mdc-slider-focus-handle-color: #00C853;
+    --mdc-slider-hover-handle-color: #00C853;
+    --mdc-slider-active-track-color: #00C853;
+    --mdc-slider-inactive-track-color: #00C853;
+    --mdc-slider-with-tick-marks-active-container-color: #fff;
+    --mdc-slider-with-tick-marks-inactive-container-color: #00C853;
+    --mat-mdc-slider-ripple-color: #00C853;
+    --mat-mdc-slider-hover-ripple-color: rgba(101, 31, 255, 0.05);
+    --mat-mdc-slider-focus-ripple-color: rgba(101, 31, 255, 0.2);
+}


### PR DESCRIPTION
[✓] Se encontró que varios elementos del material-angular estaban sin funcionar, esto se debe a que se siguen usando las librerias antiguas
[✓] Para corregir los problemas de los mat-slider de la vista /dashboard se importo el módulo MatSliderModule en el modulo de app-material, se desactivó el anterior
[✓] Los sliders en angular 16 funcionan distinto, es necesario agregar a cada uno un input dentro con las propiedades "matSliderThumb [(ngModel)]"