### PR TITLE
Fix: Chips, Inputs, Snackbars ng 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+
+## Config
+NG 16 Node 18.20.3

--- a/changelog.md
+++ b/changelog.md
@@ -2,3 +2,10 @@
 - Se encontró que varios elementos del material-angular estaban sin funcionar, esto se debe a que se siguen usando las librerias antiguas
 - Para corregir los problemas de los mat-slider de la vista /dashboard se importo el módulo MatSliderModule en el modulo de app-material
 - Los sliders en angular 16 funcionan distinto, es necesario agregar a cada uno un input dentro con las propiedades "matSliderThumb [(ngModel)]"
+
+#11/07/24 mramirez
+- Se cambio algunas librerias legacy que no renderizaban correctamente debido al cambio de etiquetas y modulo a llamar
+- Se cambio los chips para que vuelvan a funcionar, antes se usaba "mat-chip-list" y "mat-chip" ahora se usa "mat-chip-grid" y "mat-chip-row" según la documentación de migración de angular 15 a 16
+- Se agregó colores rojo y amarillo a los desplegables del dashboard para reconocer que color va con el grafíco correspondiente
+- Se centró el gráfico y se dió mas espacio a los desplegables para que pueda entrar los textos
+

--- a/src/app/app-material.module.ts
+++ b/src/app/app-material.module.ts
@@ -7,20 +7,28 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatStepperModule } from '@angular/material/stepper';
-import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/material/legacy-autocomplete';
-import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
-import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
-import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
+// import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/material/legacy-autocomplete';
+// import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
+// import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
+// import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
 // import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
-import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+// import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+// import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
-import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
+// import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatSliderModule } from '@angular/material/slider';
+import { MatChipsModule } from '@angular/material/chips';
+import { BrowserModule } from '@angular/platform-browser';
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
+import {MatSelectModule} from '@angular/material/select';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
     imports: [
@@ -45,6 +53,7 @@ import { MatSliderModule } from '@angular/material/slider';
       MatButtonToggleModule,
       MatCheckboxModule,
       MatSelectModule,
+      BrowserModule,
 
     ],
     exports: [
@@ -69,7 +78,8 @@ import { MatSliderModule } from '@angular/material/slider';
       MatButtonToggleModule,
       MatCheckboxModule,
       MatSelectModule,
-      
+      BrowserModule,
+
     ],
   })
   export class AppMaterialModule { }

--- a/src/app/complete-signup/complete-signup.component.html
+++ b/src/app/complete-signup/complete-signup.component.html
@@ -98,7 +98,7 @@
                 <div>
                     <mat-form-field appearance="fill" style="width: 400px;">
                         <mat-label>External links</mat-label>
-                        <mat-chip-list #urlList class="mat-chip-list-stacked">
+                        <mat-chip-grid #urlList class="mat-chip-list-stacked">
                             <mat-chip *ngFor="let url of urls"
                                     [removable]="true" (removed)="removeUrl(url)">
                                 {{url}}
@@ -111,14 +111,14 @@
                                     [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
                                     [matChipInputAddOnBlur]="true"
                                     (matChipInputTokenEnd)="addUrl($event)">
-                        </mat-chip-list>
+                        </mat-chip-grid>
                     </mat-form-field>
                 </div>
 
                 <div>
                     <mat-form-field appearance="fill" style="width: 400px;">
                         <mat-label>Countries</mat-label>
-                        <mat-chip-list #countryList>
+                        <mat-chip-grid #countryList>
                             <mat-chip *ngFor="let country of selectedCountries"
                                     [removable]="true" (removed)="removeCountry(country)">
                                 {{country}}
@@ -129,7 +129,7 @@
                                     formControlName="sixthCtrl"
                                     [matChipInputFor]="countryList"
                                     [matAutocomplete]="autoCountries">
-                        </mat-chip-list>
+                        </mat-chip-grid>
                         
                         <mat-autocomplete #autoCountries="matAutocomplete" (optionSelected)="selectCountry($event)">
                             <mat-option *ngFor="let country of filteredCountries | async" [value]="country">
@@ -142,7 +142,7 @@
                 <div *ngIf="userType !== 'academic'">
                     <mat-form-field appearance="fill" style="width: 400px;">
                         <mat-label>Industry sector</mat-label>
-                        <mat-chip-list #industryList>
+                        <mat-chip-grid #industryList>
                             <mat-chip *ngFor="let industry of selectedIndustries"
                                     [removable]="true" (removed)="removeIndustry(industry)">
                                 {{industry}}
@@ -153,7 +153,7 @@
                                     formControlName="seventhCtrl"
                                     [matChipInputFor]="industryList"
                                     [matAutocomplete]="autoIndustries">
-                        </mat-chip-list>
+                        </mat-chip-grid>
 
                         <mat-autocomplete #autoIndustries="matAutocomplete" (optionSelected)="selectIndustry($event)">
                             <mat-option *ngFor="let industry of filteredIndustries | async" [value]="industry">

--- a/src/app/complete-signup/complete-signup.component.ts
+++ b/src/app/complete-signup/complete-signup.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { MatStepper } from '@angular/material/stepper';
 import { MatLegacyAutocompleteSelectedEvent as MatAutocompleteSelectedEvent } from '@angular/material/legacy-autocomplete';
-import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Observable } from 'rxjs';
 import { concatMap, map, startWith } from 'rxjs/operators';
@@ -144,7 +144,7 @@ export class CompleteSignupComponent implements OnInit {
     }
   }
 
-  addUrl(event: MatChipInputEvent): void {
+  addUrl(event: any): void {
     const input = event.chipInput?.inputElement;
     const value = event.value;
     // Add the new url

--- a/src/app/imi-vars/imi-vars.component.css
+++ b/src/app/imi-vars/imi-vars.component.css
@@ -6,3 +6,13 @@
 .tooltip {
     fill: #333333;
 }
+
+.country-chip{
+    background-color: #cc333f !important;
+    --mdc-chip-label-text-color: #ffffff;
+}
+
+.industry-chip{
+    background-color: #edc951 !important;
+    --mdc-chip-label-text-color: #000000;
+}

--- a/src/app/imi-vars/imi-vars.component.html
+++ b/src/app/imi-vars/imi-vars.component.html
@@ -228,21 +228,21 @@
 
         </div>
 
-        <div style="margin-top: 30px; margin-right: 50px;">
+        <div style="margin-top: 30px; margin-right: 50px;flex: 1;">
             
-            <div #chartContainer></div>
+            <div #chartContainer style="text-align: center;"></div>
             
             <div fxLayout="row" style="margin: 0 0 10px 40px;">
                 
-                <mat-form-field appearance="fill" style="width: 200px; margin-right: 5px;">
+                <mat-form-field appearance="fill" style="margin-right: 5px;flex:1;">
                     <mat-label>Show country IMI</mat-label>
 
-                    <mat-chip-list #countryList>
-                        <mat-chip *ngFor="let country of selectedCountries" [removable]="true" (removed)="removeCountry()">
+                    <mat-chip-grid #countryList>
+                        <mat-chip-row class="country-chip" *ngFor="let country of selectedCountries" [removable]="true" (removed)="removeCountry()">
                             {{country}}
-                            <mat-icon matChipRemove>cancel</mat-icon>
-                        </mat-chip>
-                    </mat-chip-list>
+                            <mat-icon matChipRemove style="color: white;opacity: 0.75;">cancel</mat-icon>
+                        </mat-chip-row>
+                    </mat-chip-grid>
 
                     <input #countryInput matInput
                             placeholder="Type country"
@@ -258,15 +258,15 @@
 
                 </mat-form-field>
 
-                <mat-form-field appearance="fill" style="width: 200px;">
+                <mat-form-field appearance="fill" style="flex:1;">
                     <mat-label>Show industry sector IMI</mat-label>
 
-                    <mat-chip-list #industryList>
-                        <mat-chip *ngFor="let industry of selectedIndustries" [removable]="true" (removed)="removeIndustry()">
+                    <mat-chip-grid #industryList>
+                        <mat-chip  class="industry-chip" *ngFor="let industry of selectedIndustries" [removable]="true" (removed)="removeIndustry()">
                             {{industry}}
                             <mat-icon matChipRemove>cancel</mat-icon>
                         </mat-chip>
-                    </mat-chip-list>
+                    </mat-chip-grid>
 
                     <input #industryInput matInput
                             placeholder="Type industry sector"

--- a/src/app/imi-vars/imi-vars.component.ts
+++ b/src/app/imi-vars/imi-vars.component.ts
@@ -9,7 +9,7 @@ import { ProviderService } from '../services/provider.service';
 import { Util } from '../utils/util';
 import { ClientService } from '../services/client.service';
 
-import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatLegacyAutocompleteSelectedEvent as MatAutocompleteSelectedEvent } from '@angular/material/legacy-autocomplete';
 import { AcademicService } from '../services/academic.service';
 

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -150,7 +150,7 @@
                 <div>
                     <mat-form-field appearance="fill" style="width: 400px;">
                         <mat-label>External links</mat-label>
-                        <mat-chip-list #urlList class="mat-chip-list-stacked">
+                        <mat-chip-grid #urlList class="mat-chip-list-stacked">
                             <mat-chip *ngFor="let url of urls"
                                     [removable]="true" (removed)="removeUrl(url)">
                                 {{url}}
@@ -163,25 +163,25 @@
                                     [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
                                     [matChipInputAddOnBlur]="true"
                                     (matChipInputTokenEnd)="addUrl($event)">
-                        </mat-chip-list>
+                        </mat-chip-grid>
                     </mat-form-field>
                 </div>
 
                 <div>
                     <mat-form-field appearance="fill" style="width: 400px;">
                         <mat-label>Countries</mat-label>
-                        <mat-chip-list #countryList>
-                            <mat-chip *ngFor="let country of selectedCountries"
+                        <mat-chip-grid #countryList>
+                            <mat-chip-row *ngFor="let country of selectedCountries"
                                     [removable]="true" (removed)="removeCountry(country)">
                                 {{country}}
                                 <mat-icon matChipRemove>cancel</mat-icon>
-                            </mat-chip>
+                            </mat-chip-row>
                             <input #countryInput
                                     placeholder="Select countries from autocomplete list"
                                     formControlName="sixthCtrl"
                                     [matChipInputFor]="countryList"
                                     [matAutocomplete]="autoCountries">
-                        </mat-chip-list>
+                        </mat-chip-grid>
                         
                         <mat-autocomplete #autoCountries="matAutocomplete" (optionSelected)="selectCountry($event)">
                             <mat-option *ngFor="let country of filteredCountries | async" [value]="country">
@@ -194,7 +194,7 @@
                 <div *ngIf="!userIsAcademic()">
                     <mat-form-field appearance="fill" style="width: 400px;">
                         <mat-label>Industries</mat-label>
-                        <mat-chip-list #industryList>
+                        <mat-chip-grid #industryList>
                             <mat-chip *ngFor="let industry of selectedIndustries"
                                     [removable]="true" (removed)="removeIndustry(industry)">
                                 {{industry}}
@@ -205,7 +205,7 @@
                                     formControlName="seventhCtrl"
                                     [matChipInputFor]="industryList"
                                     [matAutocomplete]="autoIndustries">
-                        </mat-chip-list>
+                        </mat-chip-grid>
 
                         <mat-autocomplete #autoIndustries="matAutocomplete" (optionSelected)="selectIndustry($event)">
                             <mat-option *ngFor="let industry of filteredIndustries | async" [value]="industry">

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -9,7 +9,7 @@ import { AuthService } from '@auth0/auth0-angular';
 import { ClientService } from '../services/client.service';
 import { ProviderService } from '../services/provider.service';
 import { SharedService } from '../services/shared.service';
-import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatLegacyAutocompleteSelectedEvent as MatAutocompleteSelectedEvent } from '@angular/material/legacy-autocomplete';
 import { MatLegacyChipInputEvent as MatChipInputEvent } from '@angular/material/legacy-chips';
 import { Util } from '../utils/util';
@@ -136,7 +136,7 @@ export class ProfileComponent implements OnInit {
     }
   }
 
-  addUrl(event: MatChipInputEvent): void {
+  addUrl(event: any): void {
     const input = event.chipInput?.inputElement;
     const value = event.value;
     // Add the new url

--- a/src/app/provider-detail-dialog/provider-detail-dialog.component.ts
+++ b/src/app/provider-detail-dialog/provider-detail-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Inject } from '@angular/core';
-import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Provider } from '../models/types';
 import { Util } from '../utils/util';
 

--- a/src/app/provider-services/provider-services.component.html
+++ b/src/app/provider-services/provider-services.component.html
@@ -21,7 +21,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list1>
+                            <mat-chip-grid #list1>
                                 <mat-chip *ngFor="let service of selectedServices1"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -35,7 +35,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list1"
                                         [matAutocomplete]="autoComplete1">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete1="matAutocomplete" (optionSelected)="selectService1($event)">
                                 <mat-option *ngFor="let service of services1" [value]="service">
@@ -54,7 +54,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list2>
+                            <mat-chip-grid #list2>
                                 <mat-chip *ngFor="let service of selectedServices2"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -68,7 +68,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list2"
                                         [matAutocomplete]="autoComplete2">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete2="matAutocomplete" (optionSelected)="selectService2($event)">
                                 <mat-option *ngFor="let service of services2" [value]="service">
@@ -87,7 +87,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list3>
+                            <mat-chip-grid #list3>
                                 <mat-chip *ngFor="let service of selectedServices3"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -101,7 +101,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list3"
                                         [matAutocomplete]="autoComplete3">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete3="matAutocomplete" (optionSelected)="selectService3($event)">
                                 <mat-option *ngFor="let service of services3" [value]="service">
@@ -130,7 +130,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list4>
+                            <mat-chip-grid #list4>
                                 <mat-chip *ngFor="let service of selectedServices4"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -144,7 +144,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list4"
                                         [matAutocomplete]="autoComplete4">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete4="matAutocomplete" (optionSelected)="selectService4($event)">
                                 <mat-option *ngFor="let service of services4" [value]="service">
@@ -163,7 +163,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list5>
+                            <mat-chip-grid #list5>
                                 <mat-chip *ngFor="let service of selectedServices5"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -177,7 +177,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list5"
                                         [matAutocomplete]="autoComplete5">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete5="matAutocomplete" (optionSelected)="selectService5($event)">
                                 <mat-option *ngFor="let service of services5" [value]="service">
@@ -196,7 +196,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list6>
+                            <mat-chip-grid #list6>
                                 <mat-chip *ngFor="let service of selectedServices6"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -210,7 +210,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list6"
                                         [matAutocomplete]="autoComplete6">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete6="matAutocomplete" (optionSelected)="selectService6($event)">
                                 <mat-option *ngFor="let service of services6" [value]="service">
@@ -239,7 +239,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list7>
+                            <mat-chip-grid #list7>
                                 <mat-chip *ngFor="let service of selectedServices7"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -253,7 +253,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list7"
                                         [matAutocomplete]="autoComplete7">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete7="matAutocomplete" (optionSelected)="selectService7($event)">
                                 <mat-option *ngFor="let service of services7" [value]="service">
@@ -272,7 +272,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list8>
+                            <mat-chip-grid #list8>
                                 <mat-chip *ngFor="let service of selectedServices8"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -286,7 +286,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list8"
                                         [matAutocomplete]="autoComplete8">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete8="matAutocomplete" (optionSelected)="selectService8($event)">
                                 <mat-option *ngFor="let service of services8" [value]="service">
@@ -305,7 +305,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list9>
+                            <mat-chip-grid #list9>
                                 <mat-chip *ngFor="let service of selectedServices9"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -319,7 +319,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list9"
                                         [matAutocomplete]="autoComplete9">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete9="matAutocomplete" (optionSelected)="selectService9($event)">
                                 <mat-option *ngFor="let service of services9" [value]="service">
@@ -348,7 +348,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list10>
+                            <mat-chip-grid #list10>
                                 <mat-chip *ngFor="let service of selectedServices10"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -362,7 +362,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list10"
                                         [matAutocomplete]="autoComplete10">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete10="matAutocomplete" (optionSelected)="selectService10($event)">
                                 <mat-option *ngFor="let service of services10" [value]="service">
@@ -381,7 +381,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list11>
+                            <mat-chip-grid #list11>
                                 <mat-chip *ngFor="let service of selectedServices11"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -395,7 +395,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list11"
                                         [matAutocomplete]="autoComplete11">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete11="matAutocomplete" (optionSelected)="selectService11($event)">
                                 <mat-option *ngFor="let service of services11" [value]="service">
@@ -414,7 +414,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list12>
+                            <mat-chip-grid #list12>
                                 <mat-chip *ngFor="let service of selectedServices12"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -428,7 +428,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list12"
                                         [matAutocomplete]="autoComplete12">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete12="matAutocomplete" (optionSelected)="selectService12($event)">
                                 <mat-option *ngFor="let service of services12" [value]="service">
@@ -457,7 +457,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list13>
+                            <mat-chip-grid #list13>
                                 <mat-chip *ngFor="let service of selectedServices13"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -471,7 +471,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list13"
                                         [matAutocomplete]="autoComplete13">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete13="matAutocomplete" (optionSelected)="selectService13($event)">
                                 <mat-option *ngFor="let service of services13" [value]="service">
@@ -490,7 +490,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list14>
+                            <mat-chip-grid #list14>
                                 <mat-chip *ngFor="let service of selectedServices14"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -504,7 +504,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list14"
                                         [matAutocomplete]="autoComplete14">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete14="matAutocomplete" (optionSelected)="selectService14($event)">
                                 <mat-option *ngFor="let service of services14" [value]="service">
@@ -523,7 +523,7 @@
             
                     <div class="subdim-services" fxFlex>
                         <mat-form-field appearance="fill">
-                            <mat-chip-list #list15>
+                            <mat-chip-grid #list15>
                                 <mat-chip *ngFor="let service of selectedServices15"
                                         color="accent"
                                         [removable]="!disabledInputs" 
@@ -537,7 +537,7 @@
                                         [placeholder]="disabledInputs ? '' : 'Type service here'"
                                         [matChipInputFor]="list15"
                                         [matAutocomplete]="autoComplete15">
-                            </mat-chip-list>
+                            </mat-chip-grid>
             
                             <mat-autocomplete #autoComplete15="matAutocomplete" (optionSelected)="selectService15($event)">
                                 <mat-option *ngFor="let service of services15" [value]="service">

--- a/src/app/provider-services/provider-services.component.ts
+++ b/src/app/provider-services/provider-services.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatLegacyAutocompleteSelectedEvent as MatAutocompleteSelectedEvent } from '@angular/material/legacy-autocomplete';
-import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Provider } from '../models/types';
 
 import { ProviderService } from '../services/provider.service';

--- a/src/app/suggestions/suggestions.component.ts
+++ b/src/app/suggestions/suggestions.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { concatMap } from 'rxjs/operators';
 import { Provider } from '../models/types';
 import { ProviderDetailDialogComponent } from '../provider-detail-dialog/provider-detail-dialog.component';


### PR DESCRIPTION
✔ Se cambio algunas librerias legacy que no renderizaban correctamente debido al cambio de etiquetas y modulo a llamar
✔ Se cambio los chips para que vuelvan a funcionar, antes se usaba "mat-chip-list" y "mat-chip" ahora se usa "mat-chip-grid" y "mat-chip-row" según la documentación de migración de angular 15 a 16
✔ Se agregó colores rojo y amarillo a los desplegables del dashboard para reconocer que color va con el grafíco correspondiente
✔ Se centró el gráfico y se dió mas espacio a los desplegables para que pueda entrar los textos